### PR TITLE
Adding a --registry CLI option and resolving .npmrc as a fallback

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -5,6 +5,13 @@
  */
 var program = require("commander");
 var pkg = require("../package.json");
+var rc = require("rc");
+
+var getConfiguredNpmRegistry = function () {
+  var config = {};
+  rc("npm", config);
+  return config.registry;
+};
 
 // Parse to arguments object.
 var parseToArgs = function (argv) {
@@ -28,6 +35,7 @@ var parseToArgs = function (argv) {
     // Flags
     .option("-o, --old <package>", "Old package to diff (default `<package>@latest`)")
     .option("-n, --new <package>", "New package to diff (default `process.cwd()`)")
+    .option("-r, --registry <registry>", "The npm registry to diff the package against")
     .option("--no-colors", "Disable colors in the outputted diff")
 
     // Parse
@@ -45,6 +53,7 @@ module.exports.parse = function (argv) { // eslint-disable-line no-unused-vars
   return {
     old: args.old || null,
     new: args.new || process.cwd(),
-    colors: args.colors
+    colors: args.colors,
+    registry: args.registry || getConfiguredNpmRegistry()
   };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,27 +10,39 @@ var diff = require("./diff").diff;
 /**
  * Pack and expand a module by `npm pack`-compatible argument.
  *
- * @param {Object}    opts      Options object
- * @param {String}    opts.old  Old package
- * @param {String}    opts.new  New package
- * @param {Function}  callback  Callback `(err, results)`.
+ * @param {Object}    opts            options object
+ * @param {String}    [opts.old]      Old package
+ * @param {String}    opts.new        New package
+ * @param {String}    [opts.registry] Package registry
+ * @param {Function}  callback        Callback `(err, results)`.
  * @returns {void}
  */
 module.exports.diff = function (opts, callback) {
   opts = opts || {};
   var oldPkg = opts.old;
   var newPkg = opts.new;
+  var registry = opts.registry;
 
   // Validation
   if (!newPkg) { return void callback(new Error("Missing opts.new package")); }
 
   async.auto({
-    new: getPkg.bind(null, newPkg),
+    new: getPkg.bind(null, {
+      name: newPkg,
+      registry: registry
+    }),
 
     // If have explicit old package, go parallel. If not, do serial and infer
     // name of `<package>@latest` on npm registry.
-    old: oldPkg ? getPkg.bind(null, oldPkg) : ["new", function (results, cb) {
-      getPkg(results.new.pkgName, cb);
+    old: oldPkg ? getPkg.bind(null, {
+      name: oldPkg,
+      registry: registry
+    }) :
+    ["new", function (results, cb) {
+      getPkg({
+        name: results.new.pkgName,
+        registry: registry
+      }, cb);
     }],
 
     diff: ["new", "old", diff]

--- a/lib/package.js
+++ b/lib/package.js
@@ -24,8 +24,19 @@ var once = function (fn) {
   };
 };
 
+// Build the args for `npm pack`
+var buildNpmArgs = function (name, registry) {
+  var args = ["pack", name];
+
+  if (registry) {
+    args.push("--registry", registry);
+  }
+
+  return args;
+};
+
 // Execute `npm pack`.
-var npmPack = function (name, obj, callback) {
+var npmPack = function (info, obj, callback) {
   // Unpack results.
   var cwd = obj.tmpDir;
   if (!cwd) { return void callback(new Error("No tmpDir specified")); }
@@ -35,7 +46,8 @@ var npmPack = function (name, obj, callback) {
 
   // Set up command and arguments assuming Linux / Mac.
   var cmd = "npm";
-  var args = ["pack", name];
+  var args = buildNpmArgs(info.name, info.registry);
+
   if (/^win/.test(process.platform)) {
     // Detect and adjust commands if windows.
     cmd = "cmd";
@@ -56,11 +68,13 @@ var npmPack = function (name, obj, callback) {
     stdout += data;
   });
   proc.on("close", function (code) {
+    var fullCmd = cmd + " " + args.join(" ");
+
     if (code !== 0) {
-      return void callback(new Error("'npm pack " + name + "' exited with error code: " + code));
+      return void callback(new Error("'" + fullCmd + "' exited with error code: " + code));
     }
     if (!(stdout || "").trim()) {
-      return void callback(new Error("'npm pack " + name + "' did not capture file name"));
+      return void callback(new Error("'" + fullCmd + "' did not capture file name"));
     }
 
     callback(null, path.join(cwd, stdout.trim()));
@@ -98,11 +112,15 @@ var pkgName = function (obj, callback) {
 /**
  * Pack and expand a package by `npm pack`-compatible argument.
  *
- * @param {String}    name      The package name / path to install.
- * @param {Function}  callback  Callback `(err, data)`.
+ * @param {Object}    opts            The package name and optional registry.
+ * @param {String}    opts.name       The package name / path to install.
+ * @param {String}    [opts.registry] The npm registry for the `npm pack` call.
+ * @param {Function}  callback        Callback `(err, data)`.
  * @returns {void}
  */
-module.exports.get = function (name, callback) {
+module.exports.get = function (opts, callback) {
+  var name = opts.name;
+
   if (!name) { return void callback(new Error("No name specified")); }
 
   // Create a temporary directory to stash the gzip file, unzip it and return
@@ -110,7 +128,7 @@ module.exports.get = function (name, callback) {
   async.auto({
     tmpDir: temp.mkdir.bind(temp, null),
 
-    npmPack: ["tmpDir", npmPack.bind(null, name)],
+    npmPack: ["tmpDir", npmPack.bind(null, opts)],
 
     extract: ["npmPack", extract],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "diff": "^3.0.1",
     "file-type": "^3.8.0",
     "isbinaryfile": "^3.0.1",
+    "rc": "^1.1.6",
     "recursive-readdir": "^2.1.0",
     "tar": "^2.2.1",
     "temp": "^0.8.3"


### PR DESCRIPTION
* Adds a --registry argument.
* Uses the local .npmrc configured registry as a fallback. Necessary because the npm cwd is changed to the temp directory, resulting in different behavior compared to running `npm pack...` on its own.