### PR TITLE
Better handle (1) local .npmrc, and (2) file path arguments.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,13 @@ History
 * XXX
 -->
 
+## Unreleased
+
+* Expand any module names starting with `.`, `/`, or OS-specific path slash to
+  full absolute path to simulate `npm pack`-ing in CWD.
+* Copy `.npmrc` from expected `npm` paths to temp directory.
+  [#9](https://github.com/FormidableLabs/publish-diff/pull/9)
+
 ## 0.3.0
 
 * Add --registry CLI option and resolving .npmrc as a fallback. (**[@joelday][]**)

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ The basics:
 
   Options:
 
-    -h, --help           output usage information
-    -V, --version        output the version number
-    -o, --old <package>  Old package to diff (default `<package>@latest`)
-    -n, --new <package>  New package to diff (default `process.cwd()`)
-    --no-colors          Disable colors in the outputted diff
+    -h, --help                 output usage information
+    -V, --version              output the version number
+    -o, --old <package>        Old package to diff (default `<package>@latest`)
+    -n, --new <package>        New package to diff (default `process.cwd()`)
+    -r, --registry <registry>  The npm registry to diff the package against
+    --no-colors                Disable colors in the outputted diff
 
   Examples:
 
@@ -189,6 +190,25 @@ $ npm run preversion && \
 Similar to `publish`, you would not want to run `npm run version` because it
 has side effects -- in this case, mutating the git state of your project.
 Projects with an actual `package.json:version` script would need manual cleanup.
+
+## Notes
+
+### `.npmrc` Files
+
+`publish-diff` follows the `npm` rules for searching for `.npmrc` files --
+https://docs.npmjs.com/files/npmrc#files -- which approximates to:
+
+- `${process.cwd()}.npmrc`
+- `~/.npmrc`
+- `$NODE_GLOBAL_PATH/etc/npmrc`
+- `$SYSTEM_PATH/npm/npmrc`
+
+`publish-diff` shells to `npm pack` which will out-of-the-box work with all but
+the first of these rc file locations. The complexity is that for the actual
+`npm pack` command, `publish-diff` creates and switches to a temporary
+directory. To compensate for this behavior, if a `${process.cwd()}.npmrc` file
+is found, that is _also_ copied to the temporary directory before initiating
+any underlying `npm` commands.
 
 [trav_img]: https://api.travis-ci.org/FormidableLabs/publish-diff.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/publish-diff

--- a/lib/args.js
+++ b/lib/args.js
@@ -5,13 +5,6 @@
  */
 var program = require("commander");
 var pkg = require("../package.json");
-var rc = require("rc");
-
-var getConfiguredNpmRegistry = function () {
-  var config = {};
-  rc("npm", config);
-  return config.registry;
-};
 
 // Parse to arguments object.
 var parseToArgs = function (argv) {
@@ -54,6 +47,6 @@ module.exports.parse = function (argv) { // eslint-disable-line no-unused-vars
     old: args.old || null,
     new: args.new || process.cwd(),
     colors: args.colors,
-    registry: args.registry || getConfiguredNpmRegistry()
+    registry: args.registry
   };
 };

--- a/lib/package.js
+++ b/lib/package.js
@@ -26,13 +26,47 @@ var once = function (fn) {
 
 // Build the args for `npm pack`
 var buildNpmArgs = function (name, registry) {
-  var args = ["pack", name];
+  var args = ["pack"];
 
+  // Normalize name if start with `.`, `/`, or OS-specific path separator.
+  name = name.trim();
+  if (name && [".", "/", path.sep].indexOf(name[0]) === 0) {
+    name = path.resolve(name);
+  }
+  args.push(name);
+
+  // Add registry.
   if (registry) {
     args.push("--registry", registry);
   }
 
   return args;
+};
+
+// Copy PWD rcfile if found.
+var copyRc = function (obj, callback) {
+  if (!obj.tmpDir) { return void callback(new Error("No temp dir specified")); }
+
+  var rcSrc = path.resolve(".npmrc");
+  var rcDst = path.resolve(obj.tmpDir, ".npmrc");
+
+  async.auto({
+    read: function (cb) {
+      fs.readFile(rcSrc, function (err, data) {
+        // Allow not found.
+        if (err && err.code !== "ENOENT") {
+          return void cb(err);
+        }
+
+        cb(null, data);
+      });
+    },
+    write: ["read", function (results, cb) {
+      if (!obj.read) { return void cb(); }
+
+      fs.writeFile(rcDst, results.read, cb);
+    }]
+  }, callback);
 };
 
 // Execute `npm pack`.
@@ -128,7 +162,9 @@ module.exports.get = function (opts, callback) {
   async.auto({
     tmpDir: temp.mkdir.bind(temp, null),
 
-    npmPack: ["tmpDir", npmPack.bind(null, opts)],
+    copyRc: ["tmpDir", copyRc],
+
+    npmPack: ["copyRc", npmPack.bind(null, opts)],
 
     extract: ["npmPack", extract],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "diff": "^3.0.1",
     "file-type": "^3.8.0",
     "isbinaryfile": "^3.0.1",
-    "rc": "^1.1.6",
     "recursive-readdir": "^2.1.0",
     "tar": "^2.2.1",
     "temp": "^0.8.3"


### PR DESCRIPTION
* Expand any module names starting with `.`, `/`, or OS-specific path slash to
  full absolute path to simulate `npm pack`-ing in CWD.
* Remove `rc` module.
* Copy `.npmrc` from expected `npm` paths to temp directory. Fixes #9 

/cc @drwlrsn